### PR TITLE
feat: update theme with breakpoints values

### DIFF
--- a/packages/design-system/components/component/Component.styled.js
+++ b/packages/design-system/components/component/Component.styled.js
@@ -27,11 +27,21 @@ export const Heading = styled.h2`
   margin: 0;
   ${({ theme, typographyVariant }) =>
     theme.typography.desktop[typographyVariant]};
+
+  ${({ theme }) => theme.breakpoints.lg} {
+    ${({ theme, typographyVariant }) =>
+      theme.typography.tablet[typographyVariant]}
+  }}
 `
 
 export const Description = styled.p`
   ${({ theme, typographyVariant }) =>
     theme.typography.desktop[typographyVariant]};
+
+  ${({ theme }) => theme.breakpoints.lg} {
+    ${({ theme, typographyVariant }) =>
+      theme.typography.mobile[typographyVariant]}
+  }}
 `
 
 export const Link = styled.a`

--- a/packages/design-system/components/theme/theme.js
+++ b/packages/design-system/components/theme/theme.js
@@ -1,3 +1,13 @@
+const getBreakpoints = (bp) => {
+  const obj = {}
+
+  Object.keys(bp).forEach((key) => {
+    obj[key] = `@media (max-width: ${bp[key]}px)`
+  })
+
+  return obj
+}
+
 const theme = {
   containerHeight: "100vh",
   defaultPadding: "16px",
@@ -178,6 +188,13 @@ const theme = {
       },
     },
   },
+  breakpoints: getBreakpoints({
+    sm: 576,
+    md: 768,
+    lg: 992,
+    xl: 1200,
+    xxl: 1400,
+  }),
 }
 
 export default theme


### PR DESCRIPTION
## Name PR according scheme: type of changes (feat/fix/refactor etc.) + description
feat: update theme with breakpoints values

## Describe your changes
This PR introduces global values for breakpoints (media query sizes) that are placed in our theme. This will help us keep breakpoint sizes consistent throughout the whole project.

The `emotion` library gives us the ability to use regular CSS media query rules:
```jsx
@media (min-width: 500px) {
    border: 1px solid red;
}
```
but now, you should use:
```jsx
${({ theme }) => theme.breakpoints.lg} {
    border: 1px solid red;
}}
```
which will render the media query rule for breakpoint defined in `theme.breakpoints.lg` (992px).


## Checklist before requesting a review

- [ ] Checked which branch you would merge.
- [ ] Checked if the code follows the style guidelines of this project (use eslint and prettier).
- [ ] Performed a self-review of code (bugs, clean code rules, etc).
- [ ] Checked if added variables have unique names.
- [ ] Checked if added code/function is not a duplicate. 
- [ ] Tests have been added if possible.
- [ ] New and existing unit tests pass locally with my changes.


