### PR TITLE
fix: move box-sizing property to global styles

### DIFF
--- a/packages/design-system/.storybook/preview.js
+++ b/packages/design-system/.storybook/preview.js
@@ -22,7 +22,9 @@ export const decorators = [
       <Normalize />
       <Global
         styles={css`
-          * {
+          *,
+          *::before,
+          *::after {
             box-sizing: border-box;
           }
         `}

--- a/packages/design-system/.storybook/preview.js
+++ b/packages/design-system/.storybook/preview.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { ThemeProvider } from "@emotion/react"
+import { ThemeProvider, Global, css } from "@emotion/react"
 import { Normalize } from "styled-normalize"
 
 import theme from "design-system/theme"
@@ -20,6 +20,13 @@ export const decorators = [
   (Story) => (
     <ThemeProvider theme={theme}>
       <Normalize />
+      <Global
+        styles={css`
+          * {
+            box-sizing: border-box;
+          }
+        `}
+      />
       <Story />
     </ThemeProvider>
   ),

--- a/packages/design-system/recipes/card/Card.styled.js
+++ b/packages/design-system/recipes/card/Card.styled.js
@@ -3,7 +3,6 @@ import { css } from "@emotion/react"
 
 export const Card = styled.a`
   display: flex;
-  box-sizing: border-box;
   text-decoration: none;
   width: 100%;
   height: 100%;
@@ -33,20 +32,17 @@ export const Card = styled.a`
 export const IllustrationContainer = styled.div`
   display: inline-flex;
   justify-content: center;
-  box-sizing: border-box;
   width: 100%;
   margin: 36px 10px 18px 10px;
 `
 export const ImageContainer = styled.div`
   display: inline-flex;
   justify-content: center;
-  box-sizing: border-box;
   width: 100%;
   margin-bottom: 24px;
 `
 export const Image = styled.img`
   display: block;
-  box-sizing: border-box;
   width: 100%;
   height: ${({ imageHeight }) => imageHeight};
   object-fit: cover;
@@ -67,7 +63,6 @@ export const ContentContainer = styled.div`
           align-items: flex-start;
         `}
   justify-content: space-between;
-  box-sizing: border-box;
   width: 100%;
   gap: 24px;
   padding: ${({ paddingTop }) =>
@@ -86,6 +81,5 @@ export const Wrapper = styled.div`
           align-items: flex-start;
         `}
   gap: 24px;
-  box-sizing: border-box;
   width: 100%;
 `

--- a/packages/frontend/app/pages/_app.jsx
+++ b/packages/frontend/app/pages/_app.jsx
@@ -1,8 +1,7 @@
 import Head from "next/head"
 import { Normalize } from "styled-normalize"
-import { ThemeProvider } from "@emotion/react"
+import { ThemeProvider, Global, css } from "@emotion/react"
 import { node, shape } from "prop-types"
-import { createContext } from "react"
 
 import theme from "design-system/theme"
 
@@ -11,6 +10,13 @@ const MyApp = ({ Component, pageProps }) => (
     <Head />
     <ThemeProvider theme={theme}>
       <Normalize />
+      <Global
+        styles={css`
+          * {
+            box-sizing: border-box;
+          }
+        `}
+      />
       <Component {...pageProps} />
     </ThemeProvider>
   </>

--- a/packages/frontend/app/pages/_app.jsx
+++ b/packages/frontend/app/pages/_app.jsx
@@ -12,7 +12,9 @@ const MyApp = ({ Component, pageProps }) => (
       <Normalize />
       <Global
         styles={css`
-          * {
+          *,
+          *::before,
+          *::after {
             box-sizing: border-box;
           }
         `}


### PR DESCRIPTION
## Name PR according scheme: type of changes (feat/fix/refactor etc.) + description

## Jira issue

JIRA issue: [FSU-82](https://klau.atlassian.net/browse/FSU-82)

## Describe your changes

✨ ✨ This is a special PR for @paulgrym, just to prove that I'm not working on the project on Mondays only 😅

It removes local box-sizing properties added to the Card recipe and adds them to global styles.
They're just inline styles for now, but we can create a global styles file as soon as we need more of them.


## Checklist before requesting a review

- [x] Checked which branch you would merge.
- [x] Checked if the code follows the style guidelines of this project (use eslint and prettier).
- [x] Performed a self-review of code (bugs, clean code rules, etc).
- [x] Checked if added variables have unique names.
- [x] Checked if added code/function is not a duplicate. 
- [x] Tests have been added if possible.
- [x] New and existing unit tests pass locally with my changes.


