### PR TITLE
fix: use only gray name to keep colors consistent

### DIFF
--- a/packages/design-system/blocks/footer/Footer.jsx
+++ b/packages/design-system/blocks/footer/Footer.jsx
@@ -73,7 +73,7 @@ const Footer = () => {
             <Styled.Section>
               <Typography variant="h6">{foundationDataTitle}</Typography>
               <List gap={8}>
-                <ListItem variant="grey">
+                <ListItem variant="gray">
                   <Typography variant="bodySmall">{nip}</Typography>
                   <Typography variant="bodySmall">{krs}</Typography>
                 </ListItem>

--- a/packages/design-system/components/accordion/Accordion.styled.js
+++ b/packages/design-system/components/accordion/Accordion.styled.js
@@ -10,12 +10,12 @@ const colors = {
     backgroundColor: theme.colors.neutrals[100],
   },
   black: {
-    color: theme.colors.grey[600],
+    color: theme.colors.gray[600],
     backgroundColor: theme.colors.neutrals[100],
   },
   white: {
     color: theme.colors.neutrals[100],
-    backgroundColor: theme.colors.grey[600],
+    backgroundColor: theme.colors.gray[600],
   },
 }
 

--- a/packages/design-system/components/accordion/__stories__/Accordion.stories.mdx
+++ b/packages/design-system/components/accordion/__stories__/Accordion.stories.mdx
@@ -72,7 +72,7 @@ export const TemplateBlack = (args) => {
   const theme = useTheme()
   return (
     <Accordion {...args}>
-      <Typography color={theme.colors.grey[600]} variant="bodySmall">
+      <Typography color={theme.colors.gray[600]} variant="bodySmall">
         Tu wpisz odpowiedź na pytanie
       </Typography>
       <Button
@@ -133,7 +133,7 @@ export const TemplateFAQ = (args) => {
   const theme = useTheme()
   return (
     <Accordion {...args}>
-      <Typography color={theme.colors.grey[600]} variant="bodySmall">
+      <Typography color={theme.colors.gray[600]} variant="bodySmall">
         Proces adopcyjny polega na poznaniu rodziny, sprawdzeniu warunków
         rodziny, jej wiedzy i otwartości na wiedzę. Pierwszym krokiem jest
         wypełnienie <a href="google.com">ankiety</a> Drugim krokiem jest wizyta

--- a/packages/design-system/components/badge/Badge.styled.js
+++ b/packages/design-system/components/badge/Badge.styled.js
@@ -7,19 +7,19 @@ export const Badge = styled.div`
   background-color: ${({ variant, theme }) => {
     switch (variant) {
       case "gray":
-        return theme.colors.grey[200]
+        return theme.colors.gray[200]
       case "neutrals":
         return theme.colors.neutrals[400]
       case "primary":
         return theme.colors.primary[500]
       default:
-        return theme.colors.grey[200]
+        return theme.colors.gray[200]
     }
   }};
   color: ${({ variant, theme }) =>
     variant === "primary"
       ? theme.colors.neutrals[100]
-      : theme.colors.grey[500]};
+      : theme.colors.gray[500]};
 
   ${({ size, theme }) => {
     switch (size) {

--- a/packages/design-system/components/banner/Banner.styled.js
+++ b/packages/design-system/components/banner/Banner.styled.js
@@ -4,7 +4,7 @@ export const Banner = styled.div`
   text-align: center;
   padding: 19px;
   position: relative;
-  color: ${({ theme }) => theme.colors.grey[600]};
+  color: ${({ theme }) => theme.colors.gray[600]};
   background-color: ${({ theme }) => theme.colors.complementary[100]};
 `
 

--- a/packages/design-system/components/button/Button.styled.js
+++ b/packages/design-system/components/button/Button.styled.js
@@ -23,7 +23,7 @@ const colors = {
     filledText: theme.colors.neutrals[100],
   },
   black: {
-    mainColor: theme.colors.grey[600],
+    mainColor: theme.colors.gray[600],
     filledText: theme.colors.neutrals[100],
   },
   white: {

--- a/packages/design-system/components/input/Input.jsx
+++ b/packages/design-system/components/input/Input.jsx
@@ -44,7 +44,7 @@ const Input = ({
     {message && (
       <Typography
         variant="bodyTiny"
-        color={state ? colors[state] : theme.colors.grey[500]}
+        color={state ? colors[state] : theme.colors.gray[500]}
         data-testid="message"
       >
         {message}

--- a/packages/design-system/components/input/Input.styled.js
+++ b/packages/design-system/components/input/Input.styled.js
@@ -3,7 +3,7 @@ import styled from "@emotion/styled"
 export const Label = styled.label`
   font-family: ${({ theme }) => theme.fontFamily};
   ${({ theme }) => theme.typography.desktop.bodySmall};
-  color: ${({ theme }) => theme.colors.grey[600]};
+  color: ${({ theme }) => theme.colors.gray[600]};
 `
 
 export const Container = styled.div`
@@ -16,7 +16,7 @@ export const Input = styled.input`
   padding: ${({ state }) => (state ? "12px 38px 12px 10px" : "12px 10px")};
   margin: 8px 0;
   background: ${({ theme }) => theme.colors.neutrals[100]};
-  border: 1px solid ${({ theme }) => theme.colors.grey[400]};
+  border: 1px solid ${({ theme }) => theme.colors.gray[400]};
   border-radius: 10px;
   border-color: ${({ state, theme }) => {
     switch (state) {
@@ -25,29 +25,29 @@ export const Input = styled.input`
       case "error":
         return theme.colors.error[100]
       default:
-        return theme.colors.grey[400]
+        return theme.colors.gray[400]
     }
   }};
 
   &::placeholder {
-    color: ${({ theme }) => theme.colors.grey[400]};
+    color: ${({ theme }) => theme.colors.gray[400]};
   }
 
   &:disabled {
-    background: ${({ theme }) => theme.colors.grey[200]};
+    background: ${({ theme }) => theme.colors.gray[200]};
   }
 
   &:focus {
-    border: 1px solid ${({ theme }) => theme.colors.grey[400]};
-    outline: 4px solid ${({ theme }) => theme.colors.grey[200]};
+    border: 1px solid ${({ theme }) => theme.colors.gray[400]};
+    outline: 4px solid ${({ theme }) => theme.colors.gray[200]};
   }
 
   &:active {
-    border: 1px solid ${({ theme }) => theme.colors.grey[600]};
+    border: 1px solid ${({ theme }) => theme.colors.gray[600]};
   }
 
   &:hover {
-    border-color: ${({ theme }) => theme.colors.grey[600]};
+    border-color: ${({ theme }) => theme.colors.gray[600]};
   }
 `
 
@@ -64,7 +64,7 @@ export const Icon = styled.span`
       case "error":
         return theme.colors.error[100]
       default:
-        return theme.colors.grey[400]
+        return theme.colors.gray[400]
     }
   }};
 `

--- a/packages/design-system/components/listItem/ListItem.styled.js
+++ b/packages/design-system/components/listItem/ListItem.styled.js
@@ -9,7 +9,7 @@ export const ListItem = styled.li`
   gap: 8px;
   background-color: "transparent";
   color: ${({ variant }) =>
-    variant === "primary" ? theme.colors.primary[500] : theme.colors.grey[600]};
+    variant === "primary" ? theme.colors.primary[500] : theme.colors.gray[600]};
   ${theme.typography.desktop.bodySmall};
 `
 export const ChildContainer = styled.div`

--- a/packages/design-system/components/select/Select.styled.js
+++ b/packages/design-system/components/select/Select.styled.js
@@ -3,7 +3,7 @@ import styled from "@emotion/styled"
 export const Label = styled.label`
   font-family: ${({ theme }) => theme.fontFamily};
   ${({ theme }) => theme.typography.desktop.bodySmall};
-  color: ${({ theme }) => theme.colors.grey[600]};
+  color: ${({ theme }) => theme.colors.gray[600]};
 `
 
 export const Container = styled.div`
@@ -16,26 +16,26 @@ export const Select = styled.select`
   ${({ theme }) => theme.breakpoints.sm} {
     ${({ theme }) => theme.typography.mobile.bodySmall}
   }
-  color: ${({ theme }) => theme.colors.grey[400]};
+  color: ${({ theme }) => theme.colors.gray[400]};
   appearance: none;
   width: 100%;
   padding: 12px 40px 12px 10px;
   background: ${({ theme }) => theme.colors.neutrals[100]};
-  border: 1px solid ${({ theme }) => theme.colors.grey[400]};
+  border: 1px solid ${({ theme }) => theme.colors.gray[400]};
   border-radius: 10px;
 
   &:disabled {
-    background: ${({ theme }) => theme.colors.grey[200]};
-    color: ${({ theme }) => theme.colors.grey[400]};
+    background: ${({ theme }) => theme.colors.gray[200]};
+    color: ${({ theme }) => theme.colors.gray[400]};
   }
 
   &:focus {
-    border: 1px solid ${({ theme }) => theme.colors.grey[400]};
-    outline: 4px solid ${({ theme }) => theme.colors.grey[200]};
+    border: 1px solid ${({ theme }) => theme.colors.gray[400]};
+    outline: 4px solid ${({ theme }) => theme.colors.gray[200]};
   }
 
   &:active {
-    border: 1px solid ${({ theme }) => theme.colors.grey[600]};
+    border: 1px solid ${({ theme }) => theme.colors.gray[600]};
   }
 `
 

--- a/packages/design-system/components/textarea/Textarea.jsx
+++ b/packages/design-system/components/textarea/Textarea.jsx
@@ -39,7 +39,7 @@ const Textarea = ({
     {message && (
       <Typography
         variant="bodyTiny"
-        color={error ? theme.colors.error[100] : theme.colors.grey[500]}
+        color={error ? theme.colors.error[100] : theme.colors.gray[500]}
         data-testid="message"
       >
         {message}

--- a/packages/design-system/components/textarea/Textarea.styled.js
+++ b/packages/design-system/components/textarea/Textarea.styled.js
@@ -3,7 +3,7 @@ import styled from "@emotion/styled"
 export const Label = styled.label`
   font-family: ${({ theme }) => theme.fontFamily};
   ${({ theme }) => theme.typography.desktop.bodySmall};
-  color: ${({ theme }) => theme.colors.grey[600]};
+  color: ${({ theme }) => theme.colors.gray[600]};
 `
 
 export const Container = styled.div`
@@ -17,30 +17,30 @@ export const Textarea = styled.textarea`
   padding: ${({ error }) => (error ? "12px 38px 12px 10px" : "12px 10px")};
   margin: 8px 0;
   background: ${({ theme }) => theme.colors.neutrals[100]};
-  border: 1px solid ${({ theme }) => theme.colors.grey[400]};
+  border: 1px solid ${({ theme }) => theme.colors.gray[400]};
   border-radius: 10px;
   border-color: ${({ error, theme }) =>
-    error ? theme.colors.error[100] : theme.colors.grey[400]};
+    error ? theme.colors.error[100] : theme.colors.gray[400]};
 
   &::placeholder {
-    color: ${({ theme }) => theme.colors.grey[400]};
+    color: ${({ theme }) => theme.colors.gray[400]};
   }
 
   &:disabled {
-    background: ${({ theme }) => theme.colors.grey[200]};
+    background: ${({ theme }) => theme.colors.gray[200]};
   }
 
   &:focus {
-    border: 1px solid ${({ theme }) => theme.colors.grey[400]};
-    outline: 4px solid ${({ theme }) => theme.colors.grey[200]};
+    border: 1px solid ${({ theme }) => theme.colors.gray[400]};
+    outline: 4px solid ${({ theme }) => theme.colors.gray[200]};
   }
 
   &:active {
-    border: 1px solid ${({ theme }) => theme.colors.grey[600]};
+    border: 1px solid ${({ theme }) => theme.colors.gray[600]};
   }
 
   &:hover {
-    border-color: ${({ theme }) => theme.colors.grey[600]};
+    border-color: ${({ theme }) => theme.colors.gray[600]};
   }
 `
 
@@ -51,5 +51,5 @@ export const Icon = styled.span`
   height: 24px;
 
   color: ${({ error, theme }) =>
-    error ? theme.colors.error[100] : theme.colors.grey[400]};
+    error ? theme.colors.error[100] : theme.colors.gray[400]};
 `

--- a/packages/design-system/components/title/Title.styled.js
+++ b/packages/design-system/components/title/Title.styled.js
@@ -20,7 +20,7 @@ export const Title = styled.div`
   align-self: ${({ fullWidth }) => (fullWidth ? `stretch` : `auto`)};
   justify-content: space-between;
   position: relative;
-  color: ${({ theme }) => theme.colors.grey[500]};
+  color: ${({ theme }) => theme.colors.gray[500]};
   margin-bottom: 5px;
 `
 

--- a/packages/design-system/patterns/card/Card.styled.js
+++ b/packages/design-system/patterns/card/Card.styled.js
@@ -11,7 +11,7 @@ export const Card = styled.a`
   justify-content: start;
   padding-bottom: 36px;
   border-radius: 30px;
-  color: ${({ theme }) => theme.colors.grey[600]};
+  color: ${({ theme }) => theme.colors.gray[600]};
   background-color: ${({ bgColor = "transparent" }) => bgColor};
   ${({ linkStyle }) =>
     linkStyle &&

--- a/packages/design-system/patterns/textBanner/TextBanner.jsx
+++ b/packages/design-system/patterns/textBanner/TextBanner.jsx
@@ -79,8 +79,8 @@ TextBanner.defaultProps = {
   size: "medium",
   button: null,
   subtitleColor: theme.colors.primary[500],
-  headingColor: theme.colors.grey[600],
-  descriptionColor: theme.colors.grey[500],
+  headingColor: theme.colors.gray[600],
+  descriptionColor: theme.colors.gray[500],
   className: null,
   children: null,
 }

--- a/packages/design-system/tokens/colors/index.js
+++ b/packages/design-system/tokens/colors/index.js
@@ -14,7 +14,7 @@ const colors = {
     400: "#F8DFD8",
     500: "#F4CEC3",
   },
-  grey: {
+  gray: {
     100: "#EBEBEB",
     200: "#DFDFDF",
     300: "#C4C4C4",

--- a/packages/frontend/app/templates/ComingSoon/ComingSoon.styled.js
+++ b/packages/frontend/app/templates/ComingSoon/ComingSoon.styled.js
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled"
 
 export const Main = styled.main`
-  background-color: ${({ theme }) => theme.colors.grey[700]};
+  background-color: ${({ theme }) => theme.colors.gray[700]};
   min-height: 100vh;
   overflow: hidden;
 `
@@ -59,7 +59,7 @@ export const Img = styled.img`
   width: 100%;
   height: 100%;
   object-fit: contain;
-  background-color: ${({ theme }) => theme.colors.grey[700]};
+  background-color: ${({ theme }) => theme.colors.gray[700]};
 
   ${({ theme }) => theme.breakpoints.mobile} {
     object-fit: cover;

--- a/packages/frontend/app/templates/Contact/components/ContactInfo/ContactInfo.jsx
+++ b/packages/frontend/app/templates/Contact/components/ContactInfo/ContactInfo.jsx
@@ -11,7 +11,7 @@ const ContactInfo = () => {
   const theme = useTheme()
   return (
     <Styled.ContactInfoContainer>
-      <Typography variant="h3" as="h1" color={theme.colors.grey[600]}>
+      <Typography variant="h3" as="h1" color={theme.colors.gray[600]}>
         Bądźmy w kontakcie!
       </Typography>
       <Contact />

--- a/packages/frontend/app/templates/Contact/components/Form/Form.jsx
+++ b/packages/frontend/app/templates/Contact/components/Form/Form.jsx
@@ -14,7 +14,7 @@ const Form = ({ handleSubmit, submitting }) => {
 
   return (
     <Styled.FormContainer>
-      <Typography variant="h3" as="h2" color={theme.colors.grey[600]}>
+      <Typography variant="h3" as="h2" color={theme.colors.gray[600]}>
         Zostaw wiadomość
       </Typography>
       <Styled.Form onSubmit={handleSubmit}>

--- a/packages/frontend/app/templates/Contact/components/Response/Response.jsx
+++ b/packages/frontend/app/templates/Contact/components/Response/Response.jsx
@@ -7,10 +7,10 @@ const Response = () => {
   const theme = useTheme()
   return (
     <Styled.ResponseContainer>
-      <Typography variant="h3" as="h2" color={theme.colors.grey[600]}>
+      <Typography variant="h3" as="h2" color={theme.colors.gray[600]}>
         Wiadomość została wysłana.
       </Typography>
-      <Typography variant="bodySmall" color={theme.colors.grey[500]}>
+      <Typography variant="bodySmall" color={theme.colors.gray[500]}>
         Odpowiemy tak szybko, jak to tylko możliwe.
       </Typography>
       <Button text="Strona w budowie" variant="border" href="/" />

--- a/packages/frontend/app/templates/Documents/Document.jsx
+++ b/packages/frontend/app/templates/Documents/Document.jsx
@@ -13,17 +13,17 @@ const Documents = () => {
       <Container size="medium">
         <Styled.DocumentContainer>
           <Styled.HeaderContainer>
-            <Typography color={theme.colors.grey[600]} variant="h2">
+            <Typography color={theme.colors.gray[600]} variant="h2">
               Dokumenty do pobrania
             </Typography>
-            <Typography color={theme.colors.grey[500]} variant="bodyTitle">
+            <Typography color={theme.colors.gray[500]} variant="bodyTitle">
               Chcesz zaopiekować się naszym zwierzakiem? Tutaj znajdziesz
               niezbędne dokumenty, abyśmy mogły powierzyć go w Twoje ręce.
             </Typography>
           </Styled.HeaderContainer>
           <DocumentsTemplate />
           <Styled.DocumentsInfo>
-            <Typography color={theme.colors.grey[600]} variant="bodyTitle">
+            <Typography color={theme.colors.gray[600]} variant="bodyTitle">
               Ankietę wyślij na adres{" "}
               <a href="mailto:fundacjasterczaceuszy@gmail.com">
                 fundacjasterczaceuszy@gmail.com


### PR DESCRIPTION
## Name PR according scheme: type of changes (feat/fix/refactor etc.) + description
fix: use only gray name to keep colors consistent

## Describe your changes
This PR renames all `grey` colors to `gray` as there were some console errors about incorrect props provided. We used both: grey and gray throughout the project.

## Checklist before requesting a review

- [x] Checked which branch you would merge.
- [x] Checked if the code follows the style guidelines of this project (use eslint and prettier).
- [x] Performed a self-review of code (bugs, clean code rules, etc).
- [x] Checked if added variables have unique names.
- [x] Checked if added code/function is not a duplicate. 
- [x] Tests have been added if possible.
- [x] New and existing unit tests pass locally with my changes.


